### PR TITLE
Removed redundant "In:" label from Bearer auth dialog

### DIFF
--- a/src/core/plugins/oas3/components/http-auth.jsx
+++ b/src/core/plugins/oas3/components/http-auth.jsx
@@ -109,9 +109,6 @@ export default class HttpAuth extends React.Component {
               <Markdown source={ schema.get("description") } />
             </Row>
             <Row>
-              <p>In: <code>{ schema.get("in") }</code></p>
-            </Row>
-            <Row>
               <label>Value:</label>
               {
                 value ? <code> ****** </code>


### PR DESCRIPTION
### Description
This PR removes the redundant "In" label from the Authorization dialog for the Bearer scheme (OAS3).

### Motivation and Context
Bearer security scheme does use the `in` keyword; `in` is only used [by API keys](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#security-scheme-object).

This change reduces the clutter in the Bearer auth dialog.

### How Has This Been Tested?
Tested the local build (`npm run dev`) with [this spec](https://gist.github.com/hkosova/e4706d30f34f5c6c6456c9c9f3e96275) to make sure the change affects only Bearer auth and not other auth types.

### Screenshots (if appropriate):
![bearer-auth-dialog](https://user-images.githubusercontent.com/8576823/32188593-4c26b324-bdb9-11e7-8a3b-a540efa0f597.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
